### PR TITLE
Fix JSON methods for plotBin

### DIFF
--- a/scripts/precip/lm_analysis_plots.R
+++ b/scripts/precip/lm_analysis_plots.R
@@ -29,17 +29,53 @@ plotBin <- R6Class(
       
       return(json_out)
     },
-    fromJSON = function(json_out) {
+    fromJSON = function(jsonFileOrString,fromJSONFile = FALSE) {
+      #Method takes two arguments:
+      #jsonFileOrString = Either a string with raw serialized JSON or a file
+      #                   path to a serialzed plotBin JSON file
+      #fromJSONFile = If jsonFileOrString is a file path, this MUST be TRUE.
+      #               Otherwise set to FALSE (default)
       
-      simplifyJSON <- gsub("^\\[","",json_out)
-      simplifyJSON <- gsub("\\]$","",simplifyJSON)
+      if(fromJSONFile){
+        #Read in the raw serialized JSON data as a large character
+        json_out <- readChar(jsonFileOrString, file.info(jsonFileOrString)$size)
+      }else{
+        #JSON is already input by user as character string
+        json_out <- jsonFileOrString
+      }
       
-      jsonAtts <- gsub("\\},\\{(.*)\\},\\{.*\\},\\{.*","\\{\\1\\}",simplifyJSON)
+      #The JSON is coming in as an array of dictionaries. To jsonlite::fromJSON
+      #can read these in, but the returned format is a messy, very long list
+      #that would take some effort to decipher programatically. Instead, we can
+      #parse the JSON for each component of plotBin that we need. This may be
+      #more complicated if the object grows significantly, but for now is quite
+      #simple. Using regular expression, we group the JSON dictionaries one at a
+      #time using parentheses. We search for data after the R6 environment
+      #dictionary by specifying our first group is after a literal bracket,
+      #literal curly brace, followed by any character any number of times
+      #enclosed by },{. We repeatedly look for },{ to find remaining
+      #dictionaries
+      dictionaryParse <-"\\[\\{.*\\},\\{(.+)\\},\\{(.+)\\},\\{(.*)\\}\\]" 
+      #As we select groups, we can store the JSON of that dictionary into a
+      #variable and use this variable to populate the various data within
+      #plotBin. It's important to note that this method is inherently tied to
+      #toJSON(). Any changes in the order with which data is written out in
+      #toJSON() must be reflected here
+      jsonData <- gsub(dictionaryParse,
+                       "\\{\\1\\}",
+                       json_out)
+      jsonAtts <- gsub(dictionaryParse,
+                       "\\{\\2\\}",
+                       json_out)
+      jsonR_Col <- gsub(dictionaryParse,
+                       "\\{\\3\\}",
+                       json_out)
       
-      json_out_df <- fromJSON(json_out)
-      self$data <- jsonlite::unserializeJSON(json_out[['data']])
-      self$atts <- json_out_df
-      self$r_col <- jsonlite::unserializeJSON(json_out[['r_col']])
+      #Populate data on self using unserializeJSON to read in the data using the
+      #'correct' format from the unserialized style
+      self$data <- jsonlite::unserializeJSON(jsonData)
+      self$atts <- jsonlite::unserializeJSON(jsonAtts)
+      self$r_col <- jsonlite::unserializeJSON(jsonR_Col)
     }
   )
 )

--- a/scripts/precip/lm_analysis_plots.R
+++ b/scripts/precip/lm_analysis_plots.R
@@ -16,15 +16,29 @@ plotBin <- R6Class(
       self.toJSON()
     },
     toJSON = function() {
-      json_out <- jsonlite::serializeJSON(self)
-      json_out[['data']] <- jsonlite::serializeJSON(self$data, pretty=TRUE)
-      json_out[['atts']] <- jsonlite::serializeJSON(self$atts, pretty=TRUE)
-      json_out[['r_col']] <- jsonlite::serializeJSON(self$r_col, pretty=TRUE)
+      # json_out <- jsonlite::serializeJSON(self)
+      # json_out[['data']] <- jsonlite::serializeJSON(self$data, pretty=TRUE)
+      # json_out[['atts']] <- jsonlite::serializeJSON(self$atts, pretty=TRUE)
+      # json_out[['r_col']] <- jsonlite::serializeJSON(self$r_col, pretty=TRUE)
+      json_self <- jsonlite::serializeJSON(self)
+      json_data <- jsonlite::serializeJSON(self$data, pretty=TRUE)
+      json_atts <- jsonlite::serializeJSON(self$atts, pretty=TRUE)
+      json_r_col <- jsonlite::serializeJSON(self$r_col, pretty=TRUE)
+      
+      json_out <- paste0("[",json_self,",",json_data,",",json_atts,",",json_r_col,"]")
+      
       return(json_out)
     },
     fromJSON = function(json_out) {
+      
+      simplifyJSON <- gsub("^\\[","",json_out)
+      simplifyJSON <- gsub("\\]$","",simplifyJSON)
+      
+      jsonAtts <- gsub("\\},\\{(.*)\\},\\{.*\\},\\{.*","\\{\\1\\}",simplifyJSON)
+      
+      json_out_df <- fromJSON(json_out)
       self$data <- jsonlite::unserializeJSON(json_out[['data']])
-      self$atts <- jsonlite::unserializeJSON(json_out[['atts']])
+      self$atts <- json_out_df
       self$r_col <- jsonlite::unserializeJSON(json_out[['r_col']])
     }
   )


### PR DESCRIPTION
@rburghol @mwdunlap2004 
I think I've finally got some workable to- and from- JSON methods for our plotBin R6 object. Previously, we've had issues because `jsonlite::serializeJSON()` doesn't seem to work particularly well for environments. In defense of `jsonlite`, their developers made this clear in the documentation `?serializeJSON`:
> Apart from environments, all standard storage types are supported

Rob made some progress in getting around this in https://github.com/HARPgroup/HARParchive/pull/1328. But, the `toJSON()` method was not writing valid JSON (_I think_). It was writing a file with the following format:
``` JSON
{
dictionary 1
}
{
dictionary 2
}
{
dictionary 3
}
```

So, jsonlite could not read these in successfully (see https://github.com/HARPgroup/HARParchive/issues/1309). I found several paths forward, and perhaps ended up taking the most complicated.

### Path 1: Use JSON arrays and `jsonlite::fromJSON()`
This is easy to implement. Creating a JSON array is simple and we'd just modify the existing format to instead be the following using a simple `paste`:
``` JSON
[
{
dictionary 1
},
{
dictionary 2
},
{
dictionary 3
}
]
```
However, reading this in with `jsonlite::fromJSON()` creates a long, complicated list. Because we serialized our object, `fromJSON()` struggles to create an easily used format (thus `unserializeJSON()` exists, but it can't read in the array). 

### Path 2: Write invalid JSON to file and read in via regular expression + `jsonlite::unserializeJSON()`
This is the easiest to implement. We would only need to change the `fromJSON()` method on `plotBin` and then we could start working with our JSON files automatically, no need to rerun meta models. However, we'd have incomplete JSON files that might give us trouble in the future. We could read in the JSON files looking for all of the data between literal curly brackets using regular expression.

### Path 3: Use JSON arrays and read in via regular expressions + ` jsonlite::unserializeJSON()`
This is the path I elected to take. We write the JSON as arrays as in **Path 1**, but we read them in as in **Path 2**. It gives us valid JSON files that can still be read in. 

The biggest changes are in plotBin `toJSON()` and `fromJSON()` methods. plotBin's `toJSON()` now writes data as a JSON array using a simple `paste0:
``` r
Write JSON files individually as separate strings/JSON dictionaries
json_self <- jsonlite::serializeJSON(self)
json_data <- jsonlite::serializeJSON(self$data, pretty=TRUE)
json_atts <- jsonlite::serializeJSON(self$atts, pretty=TRUE)
json_r_col <- jsonlite::serializeJSON(self$r_col, pretty=TRUE)
Combine into a single JSON array
json_out <- paste0("[",json_self,",",json_data,",",json_atts,",",json_r_col,"]")
```
In `fromJSON()`, the code is longer so I won't copy+paste here. But, the biggest change is that the JSON dictionaries are now parsed from the array using:
``` r
#The JSON is coming in as an array of dictionaries. To jsonlite::fromJSON
#can read these in, but the returned format is a messy, very long list
#that would take some effort to decipher programatically. Instead, we can
#parse the JSON for each component of plotBin that we need. This may be
#more complicated if the object grows significantly, but for now is quite
#simple. Using regular expression, we group the JSON dictionaries one at a
#time using parentheses. We search for data after the R6 environment
#dictionary by specifying our first group is after a literal bracket,
#literal curly brace, followed by any character any number of times
#enclosed by },{. We repeatedly look for },{ to find remaining
#dictionaries
dictionaryParse <-"\\[\\{.*\\},\\{(.+)\\},\\{(.+)\\},\\{(.*)\\}\\]" 
#As we select groups, we can store the JSON of that dictionary into a
#variable and use this variable to populate the various data within
#plotBin. It's important to note that this method is inherently tied to
#toJSON(). Any changes in the order with which data is written out in
#toJSON() must be reflected here
jsonData <- gsub(dictionaryParse, "\\{\\1\\}", json_out)
jsonAtts <- gsub(dictionaryParse, "\\{\\2\\}", json_out)
jsonR_Col <- gsub(dictionaryParse, "\\{\\3\\}", json_out)
```



For proof of concept see below. The `identical` call on `atts` shows `FALSE`, but the objects appear identical to me so I'm going to count this as working:
``` r

#Proof of concept:
#Dummy data
sample_data <- data.frame(a=1:3,b=4:6)
#LM for the dummy data
testLM <- lm(b ~ a,data = sample_data)
#populate a new plotBin R6 with data. Add a list for lms and put a lm in there
plot_out <- plotBin$new(data = sample_data)
plot_out$atts$lms <- list()
#Store a few regressions using dummy data
plot_out$atts$lms[[1]] <- lm(b ~ a, data = sample_data)
plot_out$atts$lms[[2]] <- lm(a ~ b, data = sample_data)

#Store some bogus data:
plot_out$data$maxa <- max(sample_data$a)
plot_out$data$maxb <- max(sample_data$a)
#Convert plotBin object plot_out to JSON using method:
out <- plot_out$toJSON()

#A file path to write out the file
fname <- "plotBin.json"
write(out, fname)

#Create a new plotBin
readInData <- plotBin$new()
#Give fromJSON the right arguments to specify a file path
readInData$fromJSON(jsonFileOrString = fname,
                     fromJSONFile = TRUE)

identical(readInData$data,plot_out$data)
identical(readInData$atts,plot_out$atts)

```
