### PR TITLE
Added a change to try to fix permissions error on writing JSON

### DIFF
--- a/models/om/manage/migrate/01_dh_to_om
+++ b/models/om/manage/migrate/01_dh_to_om
@@ -8,4 +8,4 @@ fi
 # NOTE: segment in this module is the elementid of the om entity to be migrated TO
 
 cd /var/www/html/om
-Rscript /opt/model/om/R/set_element.R pid $segment
+Rscript /opt/model/om/R/set_element.R pid $segment $tempdir

--- a/scripts/met/metModelandScenario.R
+++ b/scripts/met/metModelandScenario.R
@@ -1,13 +1,13 @@
 #Creates the appropriate model and scenario properties for a given geo run and
 #stores ratings:
 # Example Inputs:
-# coverage_hydrocode <- "usgs_ws_02021500"
+# coverage_hydrocode <- "usgs_ws_01646000"
 # coverage_bundle <- 'watershed'
 # coverage_ftype <- 'usgs_full_drainage'
 # model_version <- 'met-1.0'
 # rankingPropName <- 'simple_lm_PRISM'
 # amalgamatePropName <- 'amalgamate_simple_lm'
-# ratingsFile <- "http://deq1.bse.vt.edu:81/met/simple_lm_nldas2_tiled/out/usgs_ws_02021500-ratings.csv"
+# ratingsFile <- "http://deq1.bse.vt.edu:81/met/simple_lm_PRISM/out/usgs_ws_01646000-ratings.csv"
 # varkey <- "prism_mod_daily"
 
 #Load in hydrotools and connect to REST


### PR DESCRIPTION
Added the temp directory to the R Script `set_element.R`. This script is called in the meta model in `om->manage->migrate` and nowhere else (or at least, nowhere else in the meta model):
```
grep -R "set_element.R" ./*
./models/om/manage/migrate/01_dh_to_om:Rscript /opt/model/om/R/set_element.R pid $segment $tempdir
```

I introduced this change because I was having trouble writing out the JSON file on this same line, constantly getting permissions errors related to trying to write it out. Now it will write out directly to the temp directory which is certainly writable. 

A corresponding change will be needed in OM. See https://github.com/HARPgroup/om/pull/601