### PR TITLE
refined tree query and disabled using manifest in lieu of tree only t…

### DIFF
--- a/models/om/river/analyze/01_summarize_children
+++ b/models/om/river/analyze/01_summarize_children
@@ -9,7 +9,9 @@ custom2=`Rscript $META_MODEL_ROOT/scripts/rest/get_property.R dh_properties $pid
 # Summarize all children
 manifest="$OM_DATA_DIR/manifest.${runid}.${elid}.log"
 # Children first, so we filter out the river seg elid
-ml=`cat $manifest | grep -v $elid`
+#ml=`cat $manifest | grep -v $elid`
+# disable this manifest loading since the next om_element_tree should take care of all relevant
+ml=""
 # Use paramter max recursive level of 4 so as not to go too far upstream
 # but insure that we get things like runoff components that are nested 4 deep
 # we could do the runoff components specially if this proves too time consuming anyhow

--- a/scripts/om/om_element_tree
+++ b/scripts/om/om_element_tree
@@ -24,8 +24,15 @@ echo "Called:  om_element_tree $elid $include_children" 1>&2
 sql="WITH RECURSIVE element_tree AS (
       SELECT p.*, 0 AS level
       FROM map_model_linkages as p
+      left outer join scen_model_element as zlevel
+      on ( zlevel.elementid = p.src_id ) 
       WHERE p.dest_id = $elid 
         AND linktype = 1
+        AND ( 
+          (zlevel.custom1 <> 'cova_upstream') 
+          OR ('cova_upstream' = '-1') 
+          OR (zlevel.custom1 is null)
+        ) 
       UNION
       SELECT c.*, p.level + 1 as level
       FROM map_model_linkages as c 


### PR DESCRIPTION
…o avoid upstream segments that are run as cached but appear in the manifest