### PR TITLE
more flexible prism handling

### DIFF
--- a/models/raster_met/met/download/02_download_PRISM
+++ b/models/raster_met/met/download/02_download_PRISM
@@ -41,7 +41,8 @@ if [ "$pexist_date" == "$todays_date" ]; then
 fi
 echo "Getting data for month ${yr}-${mo}-${da}..."
 #Download the daily PRISM data for target day, reporject, and crop
-downloadPRISM $yr $mo $da
+echo "Calling: downloadPRISM $yr $mo $da $BASE_URI"
+downloadPRISM $yr $mo $da $BASE_URI $FILE_BASE $FILE_EXT
 if [ "$originalFile" == "-9999" ]; then
   echo "PRISM download could not find $download_name ... exiting. " > problem
   exit

--- a/models/raster_met/met/met.config
+++ b/models/raster_met/met/met.config
@@ -72,6 +72,9 @@ NLDAS2_GRB_TEMPLATE=`cbp get_config $scenario met NLDAS2_GRB_TEMPLATE`
 NLDAS2_UPDATE_GRB=`cbp get_config $scenario met NLDAS2_UPDATE_GRB`
 #base_dir="/backup/meteorology/${datasource}"
 base_dir=`cbp get_config $scenario met MET_DATA_BASE`
+BASE_URI=`cbp get_config $scenario met BASE_URI`
+FILE_BASE=`cbp get_config $scenario met FILE_BASE`
+FILE_EXT=`cbp get_config $scenario met FILE_EXT`
 dataset="${datasource}_precip_"
 final_ext="repro.gtiff"
 
@@ -104,7 +107,7 @@ else
     #Find the files to import into the psql database via raster2psql
     import_files=`ls $src_dir/*.gtiff | grep $final_ext`
     #Find the 'source' files that were downloaded from REST to be clipped and reprojected
-    src_files=`ls $src_dir/*.bil`
+    src_files=`ls $src_dir/*.$FILE_EXT`
   fi
 fi
 
@@ -146,3 +149,4 @@ export TS_BAND dt
 export bboxExtent bboxwest bboxeast bboxsouth bboxnorth
 export src_dir DAILYVARKEY HOURLYVARKEY FRACTIONVARKEY RASTER_SQL_FILE END_DATETIME DAILY_DEFAULT TILE_SIZE
 export NLDAS_ROOT
+export BASE_URI


### PR DESCRIPTION
@COBrogan -- the PRISM workflow had hard-wired data source URL in it, so I made that configurable from the .con file.  Changes for this including this PR from model_meteorology: https://github.com/HARPgroup/model_meteorology/pull/145
- `downloadPRISM` now expects arguments including `$BASE_URI $FILE_BASE $FILE_EXT`
- meta_model `raster_met` now supports config element `BASE_URI=`cbp get_config $scenario met BASE_URI``